### PR TITLE
Fix C++ example loudness

### DIFF
--- a/cpp_example/enhance.cpp
+++ b/cpp_example/enhance.cpp
@@ -66,10 +66,14 @@ static Config parse_config(const std::string &path) {
   return c;
 }
 
-static std::vector<float> hann(int n) {
+
+static std::vector<float> vorbis_window(int n) {
   std::vector<float> w(n);
-  for (int i = 0; i < n; ++i)
-    w[i] = 0.5f - 0.5f * std::cos(2 * M_PI * i / n);
+  int half = n / 2;
+  for (int i = 0; i < n; ++i) {
+    double sinv = std::sin(0.5 * M_PI * (i + 0.5) / half);
+    w[i] = std::sin(0.5 * M_PI * sinv * sinv);
+  }
   return w;
 }
 
@@ -128,7 +132,8 @@ int enhance_file(const std::string &model_tar, const std::string &in_wav,
   Ort::Session df_dec(env, (base / "df_dec.onnx").c_str(), opts);
 
   size_t n_freq = cfg.fft_size / 2 + 1;
-  auto window = hann(cfg.fft_size);
+  auto window = vorbis_window(cfg.fft_size);
+  float wnorm = 2.f * cfg.hop_size / (cfg.fft_size * cfg.fft_size);
 
   SF_INFO info{};
   SNDFILE *infile = sf_open(in_wav.c_str(), SFM_READ, &info);
@@ -167,7 +172,7 @@ int enhance_file(const std::string &model_tar, const std::string &in_wav,
     }
     dft(frame, spec);
     for (size_t k = 0; k < cfg.fft_size; ++k)
-      spec_noisy[f][k] = spec[k];
+      spec_noisy[f][k] = spec[k] * wnorm;
   }
 
   // Processing buffer with stage-1 output


### PR DESCRIPTION
## Summary
- use Vorbis window and proper normalization like Rust version
- scale spectrum with `wnorm` to restore loudness

## Testing
- `cargo test --no-run --quiet` *(fails: Unable to locate HDF5 root directory and/or headers)*
- `pytest -q` *(fails: ImportError in df/scripts/test_df.py)*

------
https://chatgpt.com/codex/tasks/task_e_6854a1030b8c8327a53f7c7d93f027d3